### PR TITLE
Ahubi trafficlight dev

### DIFF
--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -100,26 +100,26 @@ class TLDetector(object):
             int: index of the closest waypoint in self.waypoints
 
         """
-        
+
         # If we don't have any waypoints return None
         if self.waypoints is None:
             return
-            
+
         # Get current position
         x = pose.position.x
         y = pose.position.y
-        
+
         # define minimum distance variable
         minimum_distance = None
         minumum_location = None
-        
+
         # Search through all the waypoints to get the closes waypoint
         for i,waypoint in enumerate(self.waypoints):
             waypoint_x = waypoint.pose.pose.position.x
             waypoint_y = waypoint.pose.pose.position.yaml
-            
+
             dist_to_waypoint = math.sqrt((waypoint_x - x) ** 2 + (waypoint_y - y) ** 2)
-            
+
             # Initialize minimum distance at first value, or get new minimum distance
             if minimum_distance is None:
                 minimum_location = i
@@ -127,8 +127,8 @@ class TLDetector(object):
             elif dist_to_waypoint <= minimum_distance:
                 minimum_location = i
                 minimum_distance = dist_to_waypoint
-        
-            return minimum_location
+
+        return minimum_location
 
     def get_light_state(self, light):
         """Determines the current color of the traffic light
@@ -171,10 +171,10 @@ class TLDetector(object):
             light_pose = Pose()
             light_pose.pose.position.x = stop_light_position[0]
             light_pose.pose.position.y = stop_light_position[1]
-            
+
             # Initialize a Waypoint, which is closest to the traffic light
             light_waypoint = self.get_closest_waypoint(light_pose)
-            
+
             # Find the closest waypoint with a traffic light (or closest traffic light)
             if light_waypoint >= car_position:
                 if light is None:
@@ -183,10 +183,10 @@ class TLDetector(object):
                 elif light_waypoint < closest_light:
                     closest_light = light_waypoint
                     light = light_pose
-            
+
         if car_position and light:
             waypoint_num_to_light = abs(car_position - closest_light)
-        
+
         if light:
             state = self.get_light_state(light)
             return light_wp, state

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -154,12 +154,12 @@ class TLDetector(object):
             location and color
 
         Returns:
-            int: index of waypoint closes to the upcoming stop line for a traffic light (-1 if none exists)
+            int: index of waypoint closest to the upcoming stop line for a traffic light (-1 if none exists)
             int: ID of traffic light color (specified in styx_msgs/TrafficLight)
 
         """
         light = None
-
+        closest_light = -1
         # List of positions that correspond to the line to stop in front of for a given intersection
         stop_line_positions = self.config['stop_line_positions']
         if(self.pose):
@@ -189,7 +189,7 @@ class TLDetector(object):
 
         if light:
             state = self.get_light_state(light)
-            return light_wp, state
+            return closest_light, state
         self.waypoints = None
         return -1, TrafficLight.UNKNOWN
 


### PR DESCRIPTION
Found two small issues in tl_detector.py:
1. minimum_location should be returned when the loop is finished and not from inside the loop, In this case it will return the first waypoint index.

2. light_wp is not defined and never set. the index of closest waypoint is stored in closest_light and should be returned.